### PR TITLE
Add tag groups to the firefox extension

### DIFF
--- a/firefox-extension/background.js
+++ b/firefox-extension/background.js
@@ -1,25 +1,74 @@
 const importID = 'import-to-creamy-videos';
+const tagImportID = 'import-to-creamy-videos-tagged';
 
-browser.contextMenus.create({
-  id: importID,
-  title: 'Import to Creamy Videos',
-  contexts: ['all'],
-});
+let tagGroups = [];
+let tagSubmenus = {};
+
+function syncMenus() {
+  browser.contextMenus.removeAll();
+
+  tagGroups = [];
+  tagSubmenus = {};
+
+  browser.contextMenus.create({
+    id: importID,
+    title: 'Import to Creamy Videos',
+    contexts: ['all'],
+  });
+
+  browser.storage.sync.get('tagGroups').then((settingItem) => {
+    tagGroups = settingItem.tagGroups || [];
+
+    if (tagGroups.length > 0) {
+      browser.contextMenus.create({
+        id: tagImportID,
+        parentId: importID,
+        title: 'Default',
+        contexts: ['all'],
+      });
+    
+      tagGroups.forEach((submenu, i) => {
+        const id = `${tagImportID}-${i}`;
+        tagSubmenus[id] = i;
+        browser.contextMenus.create({
+          id,
+          parentId: importID,
+          title: submenu.text,
+          contexts: ['all'],
+        });
+      });
+    }
+  });
+}
+
+syncMenus();
+if (!browser.storage.onChanged.hasListener(syncMenus)) {
+  browser.storage.onChanged.addListener(syncMenus);
+}
 
 browser.contextMenus.onClicked.addListener((info, tab) => {
-  if (info.menuItemId !== importID) {
+  let tags;
+
+  if (info.menuItemId === importID || info.menuItemId === tagImportID) {
+    tags = [];
+  } else if (tagSubmenus[info.menuItemId] !== undefined) {
+    const tagGroup = tagGroups[tagSubmenus[info.menuItemId]];
+    tags = tagGroup.tags;
+  } else {
+    // unhandled menu item, ignore it
+    console.warn('unhandled menu item', info.menuItemId, info);
     return;
   }
 
   const url = info.linkUrl || tab.url;
-
+  
   browser.storage.sync.get('url').then((settingItem) => {
     fetch(settingItem.url || 'http://localhost:4000/', {
       method: 'post',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: 'url=' + encodeURIComponent(url),
+      body: 'url=' + encodeURIComponent(url) + '&tags=' + encodeURIComponent(tags.join(',')),
     }).then(function (resp) {
       if (!resp.ok) {
         throw new Error(resp.statusText);

--- a/firefox-extension/options.html
+++ b/firefox-extension/options.html
@@ -5,7 +5,13 @@
   </head>
   <body>
     <form>
-      <label>Creamy Videos Importer URL: <input type="text" id="url"></label>
+      <div>
+        <label>Creamy Videos Importer URL: <input type="text" id="url"></label>
+      </div>
+      <div>
+        <label>Groups</label>
+        <textarea id="tag-groups"></textarea>
+      </div>
       <button type="submit">Save</button>
     </form>
     <script src="options.js"></script>

--- a/firefox-extension/options.html
+++ b/firefox-extension/options.html
@@ -5,15 +5,30 @@
   </head>
   <body>
     <form>
-      <div>
-        <label>Creamy Videos Importer URL: <input type="text" id="url"></label>
+      <div class="form-group">
+        <label>Creamy Videos Importer URL:</label>
+        <input type="text" id="url">
       </div>
-      <div>
-        <label>Groups</label>
-        <textarea id="tag-groups"></textarea>
+      <div class="form-group">
+        <label>
+          Tag Groups:
+          <span class="t-hint">
+            (first column is name of group, others are the tags)
+          </span>
+        </label>
+        <textarea id="tag-groups" rows="5"></textarea>
       </div>
-      <button type="submit">Save</button>
+      <div class="t-r">
+        <button type="submit">Save</button>
+      </div>
     </form>
     <script src="options.js"></script>
+    <style type="text/css">
+      .form-group { margin: 1em 0; }
+      .form-group label { display: block; font-weight: bold; }
+      .form-group input, .form-group textarea { width: 100%; }
+      .t-r { text-align: right; }
+      .t-hint { opacity: 0.7; }
+    </style>
   </body>
 </html>

--- a/firefox-extension/options.js
+++ b/firefox-extension/options.js
@@ -1,7 +1,24 @@
+function tagGroupsToText(tagGroups) {
+  return tagGroups.map((group) => {
+    return [group.text, ...group.tags].join(',');
+  }).join('\n');
+}
+
+function textToTagGroups(text) {
+  return text.split('\n').map((line) => {
+    const columns = line.split(',');
+    return {
+      text: columns[0],
+      tags: columns.slice(1),
+    };
+  }).filter(group => group.tags.length > 0);
+}
+
 function saveOptions(e) {
   e.preventDefault();
   browser.storage.sync.set({
-    url: document.querySelector('#url').value
+    url: document.querySelector('#url').value,
+    tagGroups: textToTagGroups(document.querySelector('#tag-groups').value || ''),
   });
 
   var submitButton = document.querySelector('button[type="submit"]');
@@ -14,13 +31,14 @@ function saveOptions(e) {
 function restoreOptions() {
   function setCurrentChoice(result) {
     document.querySelector('#url').value = result.url || 'http://localhost:4000/';
+    document.querySelector('#tag-groups').value = tagGroupsToText(result.tagGroups);
   }
 
   function onError(error) {
     console.log(`Error: ${error}`);
   }
 
-  var getting = browser.storage.sync.get('url');
+  var getting = browser.storage.sync.get(['url', 'tagGroups']);
   getting.then(setCurrentChoice, onError);
 }
 

--- a/firefox-extension/options.js
+++ b/firefox-extension/options.js
@@ -40,6 +40,12 @@ function restoreOptions() {
 
   var getting = browser.storage.sync.get(['url', 'tagGroups']);
   getting.then(setCurrentChoice, onError);
+
+  document.querySelector('#tag-groups').setAttribute('placeholder', [
+    'Korean BBQ,food,food:korean,food:bbq',
+    'Music,music',
+    'K-Pop,music,music:k-pop',
+  ].join('\n'));
 }
 
 document.addEventListener('DOMContentLoaded', restoreOptions);


### PR DESCRIPTION
Allows adding groups in the format of:

```english
Group Foo,tag one,tag two,tag three
Group Bar,tag A, tag B
```

![image](https://user-images.githubusercontent.com/852873/68654575-0ec37800-04e3-11ea-8d1b-7c9445de00ec.png)

These will show up in the extension context menu as submenus like:

```english
Import to Creamy Videos
  -> Default
  -> Group Foo
  -> Group Bar
```

- `Default` is like the original behaviour, and will import the video without any additional tags.
- `Group Foo` would apply the tags `tag one`, `tag two`, and `tag three` (as stated)
- `Group Bar` would apply the tags `tag A`, `tag B`

Closes #7 